### PR TITLE
[Fixes #52118273] Apply no-hosts option to clients as well

### DIFF
--- a/files/dnsmasq/defaults.conf
+++ b/files/dnsmasq/defaults.conf
@@ -7,3 +7,7 @@ strict-order
 
 # Increase from very small default of 150.
 cache-size=15000
+
+# Never serve up our own /etc/hosts entries.
+# Especially so if we are a server.
+no-hosts

--- a/files/dnsmasq/server.conf
+++ b/files/dnsmasq/server.conf
@@ -1,6 +1,3 @@
 # Don't forward requests for unqualified or RFC1597 addresses.
 domain-needed
 bogus-priv
-
-# Don't serve up local /etc/hosts entries to other nodes.
-no-hosts


### PR DESCRIPTION
Move the `no-hosts` option from the server config to the default (used by
both server and client).

nsswitch/glibc/whatever should always check `hosts(5)` first, anyway.
There's no need for dnsmasq to ever serve these entries up. It will only
lead to confusion.
## 

Tested with https://github.com/alphagov/puppet-inabox/tree/dns
