### PR TITLE
Use dnsmasq upstart branch

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,6 @@ fixtures:
     resolvconf: "git://github.com/alphagov/puppet-resolvconf.git"
     dnsmasq:
       repo: "git://github.com/alphagov/puppet-dnsmasq.git"
-      ref: "origin/anchor_reload_and_resolvconf"
+      ref: "origin/upstart"
   symlinks:
     apache: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,6 @@ fixtures:
     resolvconf: "git://github.com/alphagov/puppet-resolvconf.git"
     dnsmasq:
       repo: "git://github.com/alphagov/puppet-dnsmasq.git"
-      ref: "origin/upstart"
+      ref: "origin/gds_fork"
   symlinks:
     apache: "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,8 +3,12 @@
 # GDS internal module for managing DNS.
 #
 # Pulls in the following modules:
+#   - dnsmasq
 #   - hosts
 #   - resolvconf
+#
+# Use the dnsmasq::upstreams::upstream_servers hiera key to inject
+# upstream DNS servers for a host.
 #
 # == Parameters:
 #
@@ -23,7 +27,7 @@ class gds_dns(
     use_local => true,
   }
 
-  include dnsmasq
+  include dnsmasq::upstreams
 
   dnsmasq::conf { 'defaults':
     ensure => present,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,7 +36,8 @@ class gds_dns(
   }
 
   class { "gds_dns::${sub_class}":
-    require => [Class['resolvconf'],Class['hosts']],
+    before  => Class['resolvconf'],
+    require => Class['hosts'],
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,8 +36,7 @@ class gds_dns(
   }
 
   class { "gds_dns::${sub_class}":
-    before  => Class['resolvconf'],
-    require => Class['hosts'],
+    require => [Class['resolvconf'],Class['hosts']],
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,9 +23,7 @@ class gds_dns(
     use_local => true,
   }
 
-  class { 'dnsmasq':
-    ignore_resolvconf => true,
-  }
+  include dnsmasq
 
   dnsmasq::conf { 'defaults':
     ensure => present,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,8 +17,13 @@
 #   is included. If false, `gds_dns::client` is included.
 #   Default: false
 #
+# [*upstream_servers*]
+#   An ordered array of upstream DNS servers to proxy.
+#   Default: []
+#
 class gds_dns(
-  $server = false
+  $server           = false,
+  $upstream_servers = [],
 ) {
 
   include ::hosts
@@ -27,7 +32,9 @@ class gds_dns(
     use_local => true,
   }
 
-  include dnsmasq::upstreams
+  class {'dnsmasq':
+    upstream_servers => $upstream_servers,
+  }
 
   dnsmasq::conf { 'defaults':
     ensure => present,

--- a/spec/classes/gds_dns_spec.rb
+++ b/spec/classes/gds_dns_spec.rb
@@ -8,7 +8,7 @@ describe 'gds_dns' do
   context 'includes' do
     it { should include_class('hosts') }
     it { should contain_class('resolvconf').with_use_local(true) }
-    it { should contain_class('dnsmasq::upstreams') }
+    it { should contain_class('dnsmasq') }
   end
 
   context 'dnsmasq defaults' do

--- a/spec/classes/gds_dns_spec.rb
+++ b/spec/classes/gds_dns_spec.rb
@@ -8,7 +8,7 @@ describe 'gds_dns' do
   context 'includes' do
     it { should include_class('hosts') }
     it { should contain_class('resolvconf').with_use_local(true) }
-    it { should contain_class('dnsmasq').with_ignore_resolvconf(true) }
+    it { should contain_class('dnsmasq::upstreams') }
   end
 
   context 'dnsmasq defaults' do


### PR DESCRIPTION
After alphagov/puppet-dnsmasq#3, the ignore_resolvconf parameter no longer exists.
